### PR TITLE
回答その1

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,8 +4,23 @@ import "fmt"
 
 func main() {
 	array1 := []int{1, 2, 3, 4, 5, 6}
-	array2 := array1 /* TODO */
+	array2 := FlatMap(&array1, func(arr *[]int, v int, i int) []int {
+		if v%2 == 0 {
+			return []int{v, v}
+		} else {
+			return []int{v, v, v}
+		}
+	})
 
 	fmt.Println(array2)
 	// expect: [1 1 1 2 2 3 3 3 4 4 5 5 5 6 6]
+}
+
+func FlatMap(array *[]int, fn func(arr *[]int, value int, index int) []int) []int {
+	result := make([]int, 0)
+	for i, v := range *array {
+		ret := fn(array, v, i)
+		result = append(result, ret...)
+	}
+	return result
 }


### PR DESCRIPTION
オリジナルの TypeScript 版と同じような形式に合わせると

> array2 := array1.

に繋がるようにワンライナーを書く感じになると思ったけど自分の知識でそれを満たす方法は思いつかなかった

ので、代替案として js/ts の雰囲気が出るように関数引数を受け付けるそれっぽいリスト操作関数を追加して、main 側が式1つで収まるように書いてみた